### PR TITLE
Allow weinre server to be turned off

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ let defaultOpts = {
   verbose: false,
   debug: false,
   readTimeout: 5,
+  runServer: true,
 };
 
 function WeinreWebpackPlugin(options) {
@@ -30,7 +31,7 @@ WeinreWebpackPlugin.prototype.apply = function(compiler) {
   });
 
   compiler.plugin('done', function() {
-    if (!this.weinreServer) {
+    if (options.runServer && !this.weinreServer) {
       this.weinreServer = startServer(plugin.options);
     }
   });


### PR DESCRIPTION
The problem is that the `webpack` process never ends because the server is running.

With this new option it's possible to just inject the weinre script tag in a build/package phase.